### PR TITLE
Add non_snake_case for tests; fix CI

### DIFF
--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
 jobs:
   build:
-    runs-on: rust:1.74.0-bookworm
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout AltDSS-Rust

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -37,6 +37,7 @@ use std::process; // for exit
 
 const REDIRECT_COMMAND: &str = "redirect ./electricdss-tst/Version8/Distrib/EPRITestCircuits/ckt5/Master_ckt5.dss";
 
+#[allow(non_snake_case)]
 fn solve_scenario(circ: &ICircuit, loadmult: f64) -> Result<(f64, f64), DSSError> {
     // Solve a simple snapshot to reset most of the general state
     circ.Solution.Set_Mode(SolveModes::SnapShot)?;


### PR DESCRIPTION
- Fix CI (only a few OS images are supported)
- Allow non_snake_case for `parallel` test